### PR TITLE
Show missing OpenCode source state

### DIFF
--- a/backend/config/config.example.json
+++ b/backend/config/config.example.json
@@ -1,3 +1,4 @@
 {
-  "analyticsStorePath": "data/agent-dash.sqlite"
+  "analyticsStorePath": "data/agent-dash.sqlite",
+  "openCodeDatabasePath": "/Users/you/.local/share/opencode/opencode.db"
 }

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"os"
 
 	"github.com/ccmetz/agent-dash/backend/internal/config"
 )
@@ -13,6 +15,19 @@ func NewServer() http.Handler {
 	return mux
 }
 
+type statusResponse struct {
+	OK                 bool                `json:"ok"`
+	AnalyticsStorePath string              `json:"analyticsStorePath"`
+	UsageSource        usageSourceResponse `json:"usageSource"`
+}
+
+type usageSourceResponse struct {
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+	Available bool   `json:"available"`
+	State     string `json:"state"`
+}
+
 func statusHandler(w http.ResponseWriter, r *http.Request) {
 	config, err := config.Load()
 	if err != nil {
@@ -21,11 +36,28 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(struct {
-		OK                 bool   `json:"ok"`
-		AnalyticsStorePath string `json:"analyticsStorePath"`
-	}{
+	_ = json.NewEncoder(w).Encode(statusResponse{
 		OK:                 true,
 		AnalyticsStorePath: config.AnalyticsStorePath,
+		UsageSource:        openCodeUsageSourceStatus(config.OpenCodeDatabasePath),
 	})
+}
+
+func openCodeUsageSourceStatus(path string) usageSourceResponse {
+	usageSource := usageSourceResponse{
+		Name:      "OpenCode",
+		Path:      path,
+		Available: true,
+		State:     "available",
+	}
+
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		usageSource.Available = false
+		usageSource.State = "missing"
+	} else if err != nil {
+		usageSource.Available = false
+		usageSource.State = "unavailable"
+	}
+
+	return usageSource
 }

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -23,6 +24,12 @@ func TestStatusUsesBuiltInConfigDefaultsWithoutLocalConfig(t *testing.T) {
 	var body struct {
 		OK                 bool   `json:"ok"`
 		AnalyticsStorePath string `json:"analyticsStorePath"`
+		UsageSource        struct {
+			Name      string `json:"name"`
+			Path      string `json:"path"`
+			Available bool   `json:"available"`
+			State     string `json:"state"`
+		} `json:"usageSource"`
 	}
 	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
 		t.Fatalf("expected JSON response: %v", err)
@@ -33,5 +40,93 @@ func TestStatusUsesBuiltInConfigDefaultsWithoutLocalConfig(t *testing.T) {
 	}
 	if body.AnalyticsStorePath != filepath.Join("data", "agent-dash.sqlite") {
 		t.Fatalf("expected default Analytics Store path, got %q", body.AnalyticsStorePath)
+	}
+	if body.UsageSource.Name != "OpenCode" {
+		t.Fatalf("expected OpenCode Usage Source, got %q", body.UsageSource.Name)
+	}
+}
+
+func TestStatusReportsConfiguredOpenCodeUsageSourceAvailable(t *testing.T) {
+	usageSourcePath := filepath.Join(t.TempDir(), "opencode.db")
+	if err := os.WriteFile(usageSourcePath, []byte("sqlite"), 0o600); err != nil {
+		t.Fatalf("failed to write Usage Source database: %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "local.json")
+	if err := os.WriteFile(configPath, []byte(`{"openCodeDatabasePath":"`+usageSourcePath+`"}`), 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	t.Setenv("AGENT_DASH_CONFIG", configPath)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	response := httptest.NewRecorder()
+
+	NewServer().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", response.Code)
+	}
+
+	var body struct {
+		UsageSource struct {
+			Path      string `json:"path"`
+			Available bool   `json:"available"`
+			State     string `json:"state"`
+		} `json:"usageSource"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("expected JSON response: %v", err)
+	}
+
+	if body.UsageSource.Path != usageSourcePath {
+		t.Fatalf("expected configured Usage Source path, got %q", body.UsageSource.Path)
+	}
+	if !body.UsageSource.Available {
+		t.Fatalf("expected Usage Source to be available")
+	}
+	if body.UsageSource.State != "available" {
+		t.Fatalf("expected available Usage Source state, got %q", body.UsageSource.State)
+	}
+}
+
+func TestStatusReportsMissingOpenCodeUsageSourceWithoutFailing(t *testing.T) {
+	usageSourcePath := filepath.Join(t.TempDir(), "missing-opencode.db")
+	configPath := filepath.Join(t.TempDir(), "local.json")
+	if err := os.WriteFile(configPath, []byte(`{"openCodeDatabasePath":"`+usageSourcePath+`"}`), 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	t.Setenv("AGENT_DASH_CONFIG", configPath)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	response := httptest.NewRecorder()
+
+	NewServer().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected missing Usage Source to be non-fatal, got status %d", response.Code)
+	}
+
+	var body struct {
+		OK          bool `json:"ok"`
+		UsageSource struct {
+			Path      string `json:"path"`
+			Available bool   `json:"available"`
+			State     string `json:"state"`
+		} `json:"usageSource"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("expected JSON response: %v", err)
+	}
+
+	if !body.OK {
+		t.Fatalf("expected status to stay ok when Usage Source is missing")
+	}
+	if body.UsageSource.Path != usageSourcePath {
+		t.Fatalf("expected configured Usage Source path, got %q", body.UsageSource.Path)
+	}
+	if body.UsageSource.Available {
+		t.Fatalf("expected Usage Source to be unavailable")
+	}
+	if body.UsageSource.State != "missing" {
+		t.Fatalf("expected missing Usage Source state, got %q", body.UsageSource.State)
 	}
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -8,11 +8,20 @@ import (
 )
 
 type Config struct {
-	AnalyticsStorePath string `json:"analyticsStorePath"`
+	AnalyticsStorePath   string `json:"analyticsStorePath"`
+	OpenCodeDatabasePath string `json:"openCodeDatabasePath"`
 }
 
 func Default() Config {
-	return Config{AnalyticsStorePath: filepath.Join("data", "agent-dash.sqlite")}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		homeDir = ""
+	}
+
+	return Config{
+		AnalyticsStorePath:   filepath.Join("data", "agent-dash.sqlite"),
+		OpenCodeDatabasePath: filepath.Join(homeDir, ".local", "share", "opencode", "opencode.db"),
+	}
 }
 
 func Load() (Config, error) {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -17,11 +17,15 @@ func TestLoadUsesBuiltInDefaultsWhenLocalConfigIsMissing(t *testing.T) {
 	if config.AnalyticsStorePath != filepath.Join("data", "agent-dash.sqlite") {
 		t.Fatalf("expected default Analytics Store path, got %q", config.AnalyticsStorePath)
 	}
+	expectedOpenCodePath := filepath.Join(mustHomeDir(t), ".local", "share", "opencode", "opencode.db")
+	if config.OpenCodeDatabasePath != expectedOpenCodePath {
+		t.Fatalf("expected default OpenCode database path, got %q", config.OpenCodeDatabasePath)
+	}
 }
 
 func TestLoadUsesValuesFromJSONConfigFile(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "local.json")
-	if err := os.WriteFile(configPath, []byte(`{"analyticsStorePath":"custom/analytics.sqlite"}`), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte(`{"analyticsStorePath":"custom/analytics.sqlite","openCodeDatabasePath":"custom/opencode.sqlite"}`), 0o600); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
 	}
 	t.Setenv("AGENT_DASH_CONFIG", configPath)
@@ -33,6 +37,9 @@ func TestLoadUsesValuesFromJSONConfigFile(t *testing.T) {
 
 	if config.AnalyticsStorePath != "custom/analytics.sqlite" {
 		t.Fatalf("expected configured Analytics Store path, got %q", config.AnalyticsStorePath)
+	}
+	if config.OpenCodeDatabasePath != "custom/opencode.sqlite" {
+		t.Fatalf("expected configured OpenCode database path, got %q", config.OpenCodeDatabasePath)
 	}
 }
 
@@ -46,4 +53,14 @@ func TestLoadReturnsErrorForInvalidJSONConfig(t *testing.T) {
 	if _, err := Load(); err == nil {
 		t.Fatalf("expected invalid config JSON to return an error")
 	}
+}
+
+func mustHomeDir(t *testing.T) string {
+	t.Helper()
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("expected home directory: %v", err)
+	}
+	return homeDir
 }

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -13,17 +13,31 @@ describe('Usage Overview shell', () => {
       'fetch',
       vi.fn(
         async () =>
-          new Response(JSON.stringify({ ok: true, analyticsStorePath: 'data/agent-dash.sqlite' }), {
-            headers: { 'Content-Type': 'application/json' },
-          }),
+          new Response(
+            JSON.stringify({
+              ok: true,
+              analyticsStorePath: 'data/agent-dash.sqlite',
+              usageSource: {
+                name: 'OpenCode',
+                path: '/Users/test/.local/share/opencode/opencode.db',
+                available: true,
+                state: 'available',
+              },
+            }),
+            {
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
       ),
     );
 
     render(App);
 
     expect(await screen.findByText('Usage Overview')).toBeTruthy();
-    expect(await screen.findByText('Connected')).toBeTruthy();
+    expect(await screen.findAllByText('Connected')).toHaveLength(2);
     expect(await screen.findByText('data/agent-dash.sqlite')).toBeTruthy();
+    expect(await screen.findByText('OpenCode Usage Source')).toBeTruthy();
+    expect(await screen.findByText('/Users/test/.local/share/opencode/opencode.db')).toBeTruthy();
   });
 
   it('shows a disconnected state when backend status fails', async () => {
@@ -35,7 +49,39 @@ describe('Usage Overview shell', () => {
     render(App);
 
     expect(await screen.findByText('Usage Overview')).toBeTruthy();
-    expect(await screen.findByText('Disconnected')).toBeTruthy();
-    expect(await screen.findByText('Waiting for backend status...')).toBeTruthy();
+    expect(await screen.findAllByText('Disconnected')).toHaveLength(2);
+    expect(await screen.findAllByText('Waiting for backend status...')).toHaveLength(2);
+  });
+
+  it('shows setup guidance when the OpenCode Usage Source is missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              analyticsStorePath: 'data/agent-dash.sqlite',
+              usageSource: {
+                name: 'OpenCode',
+                path: '/Users/test/.local/share/opencode/opencode.db',
+                available: false,
+                state: 'missing',
+              },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          ),
+      ),
+    );
+
+    render(App);
+
+    expect(await screen.findByText('OpenCode Usage Source missing')).toBeTruthy();
+    expect(
+      await screen.findAllByText('/Users/test/.local/share/opencode/opencode.db'),
+    ).toHaveLength(2);
+    expect(
+      await screen.findByText('Open OpenCode once, then refresh this dashboard.'),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,13 +1,23 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
+import PanelCard from './ui/PanelCard.vue';
+import StatusItem from './ui/StatusItem.vue';
 
 type Status = {
   ok: boolean;
   analyticsStorePath: string;
+  usageSource?: {
+    name: string;
+    path: string;
+    available: boolean;
+    state: string;
+  };
 };
 
 const status = ref<Status | null>(null);
 const error = ref(false);
+
+const waitingMessage = 'Waiting for backend status...';
 
 onMounted(async () => {
   try {
@@ -20,6 +30,18 @@ onMounted(async () => {
     error.value = true;
   }
 });
+
+function backendStatus() {
+  if (status.value?.ok) return 'connected';
+  if (error.value) return 'disconnected';
+  return 'connecting';
+}
+
+function usageSourceStatus() {
+  if (status.value?.usageSource?.available) return 'connected';
+  if (status.value?.usageSource?.state === 'missing' || error.value) return 'disconnected';
+  return 'connecting';
+}
 </script>
 
 <template>
@@ -32,34 +54,37 @@ onMounted(async () => {
       </p>
     </section>
 
-    <section
-      class="border-panel-border bg-panel shadow-panel rounded-panel mt-14 w-full max-w-lg space-y-4 border p-6 sm:p-8"
-      aria-label="Backend status"
+    <PanelCard
+      v-if="status?.usageSource?.state === 'missing'"
+      class="mt-10 space-y-4"
+      aria-label="Usage Source setup"
     >
-      <span
-        v-if="status?.ok"
-        class="bg-status-success text-status-success-fg inline-flex rounded-full px-3 py-1.5 font-bold"
-      >
-        Connected
-      </span>
-      <span
-        v-else-if="error"
-        class="bg-status-danger text-status-danger-fg inline-flex rounded-full px-3 py-1.5 font-bold"
-      >
-        Disconnected
-      </span>
-      <span
-        v-else
-        class="bg-status-neutral text-status-neutral-fg inline-flex rounded-full px-3 py-1.5 font-bold"
-      >
-        Connecting
-      </span>
-      <p class="text-app-accent pt-2 text-xs font-bold tracking-[0.12em] uppercase">
-        Analytics Store
+      <p class="text-app-accent text-xs font-bold tracking-[0.12em] uppercase">Setup needed</p>
+      <h2 class="text-app-fg-strong m-0 text-2xl font-bold">OpenCode Usage Source missing</h2>
+      <p class="text-app-muted m-0 max-w-xl text-lg leading-7">
+        Agent Dash could not find OpenCode's local database, so there is no Usage Metadata to show
+        yet.
       </p>
-      <p class="text-app-fg-strong m-0 wrap-anywhere font-mono">
-        {{ status?.analyticsStorePath ?? 'Waiting for backend status...' }}
+      <p class="text-app-fg-strong m-0 font-bold">
+        Open OpenCode once, then refresh this dashboard.
       </p>
-    </section>
+      <p class="text-app-muted m-0">Checked path:</p>
+      <p class="text-app-fg-strong m-0 wrap-anywhere font-mono">{{ status.usageSource.path }}</p>
+    </PanelCard>
+
+    <PanelCard class="mt-14 divide-y divide-panel-border" aria-label="Backend status">
+      <StatusItem
+        class="pb-6"
+        label="Analytics Store"
+        :status="backendStatus()"
+        :value="status?.analyticsStorePath ?? waitingMessage"
+      />
+      <StatusItem
+        class="pt-6"
+        label="OpenCode Usage Source"
+        :status="usageSourceStatus()"
+        :value="status?.usageSource?.path ?? waitingMessage"
+      />
+    </PanelCard>
   </main>
 </template>

--- a/frontend/src/ui/PanelCard.vue
+++ b/frontend/src/ui/PanelCard.vue
@@ -1,0 +1,7 @@
+<template>
+  <section
+    class="border-panel-border bg-panel shadow-panel rounded-panel w-full max-w-3xl border p-6 sm:p-8"
+  >
+    <slot />
+  </section>
+</template>

--- a/frontend/src/ui/StatusBadge.vue
+++ b/frontend/src/ui/StatusBadge.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+defineProps<{
+  status: 'connected' | 'connecting' | 'disconnected';
+}>();
+</script>
+
+<template>
+  <span
+    v-if="status === 'connected'"
+    class="bg-status-success text-status-success-fg inline-flex rounded-full px-3 py-1.5 font-bold"
+  >
+    Connected
+  </span>
+  <span
+    v-else-if="status === 'disconnected'"
+    class="bg-status-danger text-status-danger-fg inline-flex rounded-full px-3 py-1.5 font-bold"
+  >
+    Disconnected
+  </span>
+  <span
+    v-else
+    class="bg-status-neutral text-status-neutral-fg inline-flex rounded-full px-3 py-1.5 font-bold"
+  >
+    Connecting
+  </span>
+</template>

--- a/frontend/src/ui/StatusItem.vue
+++ b/frontend/src/ui/StatusItem.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import StatusBadge from './StatusBadge.vue';
+
+defineProps<{
+  label: string;
+  value: string;
+  status: 'connected' | 'connecting' | 'disconnected';
+}>();
+</script>
+
+<template>
+  <div class="space-y-4">
+    <StatusBadge :status="status" />
+    <p class="text-app-accent text-xs font-bold tracking-[0.12em] uppercase">{{ label }}</p>
+    <p class="text-app-fg-strong m-0 wrap-anywhere font-mono">{{ value }}</p>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Add OpenCode database path configuration with a standard default and example override.
- Report OpenCode Usage Source availability from the backend status API without failing when missing.
- Show connected/missing OpenCode Usage Source status and setup guidance in the Usage Overview.

## Verification
- pnpm --dir frontend format:check
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm test

Closes #3