### PR TITLE
Add manual usage sync diagnostics

### DIFF
--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/ccmetz/agent-dash/backend/internal/config"
 	"github.com/ccmetz/agent-dash/backend/internal/usage"
@@ -16,6 +17,7 @@ import (
 func NewServer() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/status", statusHandler)
+	mux.HandleFunc("POST /api/usage-sync", syncHandler)
 	return mux
 }
 
@@ -23,6 +25,7 @@ type statusResponse struct {
 	OK                 bool                `json:"ok"`
 	AnalyticsStorePath string              `json:"analyticsStorePath"`
 	UsageSource        usageSourceResponse `json:"usageSource"`
+	UsageSync          usageSyncResponse   `json:"usageSync"`
 }
 
 type usageSourceResponse struct {
@@ -32,6 +35,14 @@ type usageSourceResponse struct {
 	State     string `json:"state"`
 }
 
+type usageSyncResponse struct {
+	Status      string             `json:"status"`
+	LastRun     *usage.SyncResult  `json:"lastRun,omitempty"`
+	RecentRuns  []usage.SyncResult `json:"recentRuns"`
+	NextPollAt  string             `json:"nextPollAt"`
+	PollSeconds int                `json:"pollSeconds"`
+}
+
 func statusHandler(w http.ResponseWriter, r *http.Request) {
 	config, err := config.Load()
 	if err != nil {
@@ -39,12 +50,37 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	runs, _ := usage.RecentSyncRuns(r.Context(), config.AnalyticsStorePath, 5)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(statusResponse{
 		OK:                 true,
 		AnalyticsStorePath: config.AnalyticsStorePath,
 		UsageSource:        openCodeUsageSourceStatus(config.OpenCodeDatabasePath),
+		UsageSync:          syncStatus(runs),
 	})
+}
+
+func syncHandler(w http.ResponseWriter, r *http.Request) {
+	config, err := config.Load()
+	if err != nil {
+		http.Error(w, "failed to load config", http.StatusInternalServerError)
+		return
+	}
+	result, syncErr := usage.SyncOpenCode(r.Context(), config.OpenCodeDatabasePath, config.AnalyticsStorePath)
+	w.Header().Set("Content-Type", "application/json")
+	if syncErr != nil {
+		w.WriteHeader(http.StatusBadGateway)
+	}
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+func syncStatus(runs []usage.SyncResult) usageSyncResponse {
+	response := usageSyncResponse{Status: "never_synced", RecentRuns: runs, PollSeconds: 60, NextPollAt: time.Now().UTC().Add(60 * time.Second).Format(time.RFC3339)}
+	if len(runs) > 0 {
+		response.LastRun = &runs[0]
+		response.Status = runs[0].Status
+	}
+	return response
 }
 
 func openCodeUsageSourceStatus(path string) usageSourceResponse {

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -175,6 +175,61 @@ func TestStatusReportsMissingOpenCodeUsageSourceWithoutFailing(t *testing.T) {
 	}
 }
 
+func TestManualUsageSyncEndpointSyncsOpenCodeUsageAndStatusShowsLastRun(t *testing.T) {
+	dir := t.TempDir()
+	usageSourcePath := filepath.Join(dir, "opencode.db")
+	storePath := filepath.Join(dir, "analytics.db")
+	createSupportedOpenCodeDatabase(t, usageSourcePath)
+	db := openSQLite(t, usageSourcePath)
+	execSQL(t, db, `insert into project (id, worktree, name, time_created, time_updated) values ('proj_1', '/work/agent-dash', 'Agent Dash', 1000, 2000)`)
+	execSQL(t, db, `insert into session (id, project_id, title, time_created, time_updated, time_archived) values ('ses_1', 'proj_1', 'Manual sync', 3000, 4000, null)`)
+	execSQL(t, db, `insert into message (id, session_id, time_created, time_updated, data) values ('msg_1', 'ses_1', 5000, 6000, '{"role":"assistant","modelID":"claude-opus-4-5","providerID":"opencode","cost":0.25,"tokens":{"input":10,"output":20,"reasoning":3,"cache":{"read":4,"write":5}},"finish":"stop"}')`)
+	db.Close()
+	configPath := filepath.Join(dir, "local.json")
+	if err := os.WriteFile(configPath, []byte(`{"openCodeDatabasePath":"`+usageSourcePath+`","analyticsStorePath":"`+storePath+`"}`), 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	t.Setenv("AGENT_DASH_CONFIG", configPath)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/usage-sync", nil)
+	response := httptest.NewRecorder()
+	NewServer().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected manual sync status 200, got %d", response.Code)
+	}
+	var syncBody struct {
+		Status   string `json:"status"`
+		Inserted int    `json:"inserted"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&syncBody); err != nil {
+		t.Fatalf("expected manual sync JSON response: %v", err)
+	}
+	if syncBody.Status != "success" || syncBody.Inserted != 3 {
+		t.Fatalf("expected successful manual sync counts, got %+v", syncBody)
+	}
+
+	statusRequest := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	statusResponse := httptest.NewRecorder()
+	NewServer().ServeHTTP(statusResponse, statusRequest)
+	var statusBody struct {
+		UsageSync struct {
+			Status  string `json:"status"`
+			LastRun *struct {
+				Inserted int `json:"inserted"`
+			} `json:"lastRun"`
+			PollSeconds int    `json:"pollSeconds"`
+			NextPollAt  string `json:"nextPollAt"`
+		} `json:"usageSync"`
+	}
+	if err := json.NewDecoder(statusResponse.Body).Decode(&statusBody); err != nil {
+		t.Fatalf("expected status JSON response: %v", err)
+	}
+	if statusBody.UsageSync.Status != "success" || statusBody.UsageSync.LastRun.Inserted != 3 || statusBody.UsageSync.PollSeconds != 60 || statusBody.UsageSync.NextPollAt == "" {
+		t.Fatalf("expected status sync diagnostics, got %+v", statusBody.UsageSync)
+	}
+}
+
 func createSupportedOpenCodeDatabase(t *testing.T, path string) {
 	t.Helper()
 	db := openSQLite(t, path)

--- a/backend/internal/usage/sync.go
+++ b/backend/internal/usage/sync.go
@@ -4,22 +4,40 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
 
 const openCodeSource = "opencode"
 
-var requiredOpenCodeSchema = map[string][]string{
-	"project": {"id", "worktree", "name", "time_created", "time_updated"},
-	"session": {"id", "project_id", "title", "time_created", "time_updated", "time_archived"},
-	"message": {"id", "session_id", "time_created", "time_updated", "data"},
+var requiredOpenCodeSchema = []struct {
+	table   string
+	columns []string
+}{
+	{"project", []string{"id", "worktree", "name", "time_created", "time_updated"}},
+	{"session", []string{"id", "project_id", "title", "time_created", "time_updated", "time_archived"}},
+	{"message", []string{"id", "session_id", "time_created", "time_updated", "data"}},
 }
 
 type UnsupportedOpenCodeSchemaError struct {
 	Missing string
+}
+
+type SyncResult struct {
+	Status       string `json:"status"`
+	StartedAt    string `json:"startedAt"`
+	FinishedAt   string `json:"finishedAt"`
+	Inserted     int    `json:"inserted"`
+	Updated      int    `json:"updated"`
+	Skipped      int    `json:"skipped"`
+	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
 func (err UnsupportedOpenCodeSchemaError) Error() string {
@@ -123,62 +141,121 @@ const upsertModelCallSQL = `
 		source_updated_at = excluded.source_updated_at
 `
 
-func SyncOpenCode(ctx context.Context, sourcePath, storePath string) error {
+func SyncOpenCode(ctx context.Context, sourcePath, storePath string) (result SyncResult, err error) {
+	result = SyncResult{Status: "success", StartedAt: time.Now().UTC().Format(time.RFC3339)}
 	log.Printf("starting OpenCode Usage Sync source=%q analytics_store=%q", sourcePath, storePath)
 
 	source, err := sql.Open("sqlite", sourcePath)
 	if err != nil {
-		return err
+		result.Status = "error"
+		result.ErrorMessage = sanitizeSyncError(err)
+		return result, err
 	}
 	defer source.Close()
 
-	store, err := sql.Open("sqlite", storePath)
+	store, err := openAnalyticsStore(storePath)
 	if err != nil {
-		return err
+		result.Status = "error"
+		result.ErrorMessage = sanitizeSyncError(err)
+		return result, err
 	}
 	defer store.Close()
+	_ = ensureAnalyticsStore(ctx, store)
+	defer func() {
+		result.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+		recordSyncRun(ctx, store, &result)
+	}()
 
 	if err := ValidateOpenCodeSchema(ctx, source); err != nil {
 		log.Printf("OpenCode Usage Sync schema validation failed: %v", err)
-		return err
+		result.Status = "error"
+		result.ErrorMessage = sanitizeSyncError(err)
+		return result, err
 	}
 
 	if err := ensureAnalyticsStore(ctx, store); err != nil {
-		return err
+		result.Status = "error"
+		result.ErrorMessage = sanitizeSyncError(err)
+		return result, err
 	}
-	projectCount, err := syncProjects(ctx, source, store)
+	projectCount, err := syncProjects(ctx, source, store, &result)
 	if err != nil {
-		return err
+		result.Status = "error"
+		result.ErrorMessage = sanitizeSyncError(err)
+		return result, err
 	}
 	log.Printf("synced OpenCode Projects count=%d", projectCount)
 
-	agentSessionCount, err := syncAgentSessions(ctx, source, store)
+	agentSessionCount, err := syncAgentSessions(ctx, source, store, &result)
 	if err != nil {
-		return err
+		result.Status = "error"
+		result.ErrorMessage = sanitizeSyncError(err)
+		return result, err
 	}
 	log.Printf("synced OpenCode Agent Sessions count=%d", agentSessionCount)
 
-	modelCallCount, err := syncModelCalls(ctx, source, store)
+	modelCallCount, err := syncModelCalls(ctx, source, store, &result)
 	if err != nil {
-		return err
+		result.Status = "error"
+		result.ErrorMessage = sanitizeSyncError(err)
+		return result, err
 	}
 	log.Printf("synced OpenCode Model Calls count=%d", modelCallCount)
 	log.Printf("finished OpenCode Usage Sync source=%q analytics_store=%q", sourcePath, storePath)
-	return nil
+	return result, nil
+}
+
+func RecentSyncRuns(ctx context.Context, storePath string, limit int) ([]SyncResult, error) {
+	if _, err := os.Stat(storePath); errors.Is(err, os.ErrNotExist) {
+		return []SyncResult{}, nil
+	} else if err != nil {
+		return nil, err
+	}
+	store, err := openAnalyticsStore(storePath)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	if err := ensureAnalyticsStore(ctx, store); err != nil {
+		return nil, err
+	}
+	rows, err := store.QueryContext(ctx, `select status, started_at, finished_at, inserted_count, updated_count, skipped_count, coalesce(error_message, '') from sync_runs order by id desc limit ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	runs := []SyncResult{}
+	for rows.Next() {
+		var run SyncResult
+		if err := rows.Scan(&run.Status, &run.StartedAt, &run.FinishedAt, &run.Inserted, &run.Updated, &run.Skipped, &run.ErrorMessage); err != nil {
+			return nil, err
+		}
+		runs = append(runs, run)
+	}
+	return runs, rows.Err()
+}
+
+func openAnalyticsStore(storePath string) (*sql.DB, error) {
+	if dir := filepath.Dir(storePath); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, err
+		}
+	}
+	return sql.Open("sqlite", storePath)
 }
 
 func ValidateOpenCodeSchema(ctx context.Context, db *sql.DB) error {
-	for table, requiredColumns := range requiredOpenCodeSchema {
-		columns, err := tableColumns(ctx, db, table)
+	for _, required := range requiredOpenCodeSchema {
+		columns, err := tableColumns(ctx, db, required.table)
 		if err != nil {
 			return err
 		}
 		if len(columns) == 0 {
-			return UnsupportedOpenCodeSchemaError{Missing: "table " + table}
+			return UnsupportedOpenCodeSchemaError{Missing: "table " + required.table}
 		}
-		for _, column := range requiredColumns {
+		for _, column := range required.columns {
 			if !columns[column] {
-				return UnsupportedOpenCodeSchemaError{Missing: "column " + table + "." + column}
+				return UnsupportedOpenCodeSchemaError{Missing: "column " + required.table + "." + column}
 			}
 		}
 	}
@@ -244,6 +321,16 @@ func ensureAnalyticsStore(ctx context.Context, db *sql.DB) error {
 			source_updated_at text not null,
 			unique(source, source_id)
 		)`,
+		`create table if not exists sync_runs (
+			id integer primary key,
+			status text not null,
+			started_at text not null,
+			finished_at text not null,
+			inserted_count integer not null,
+			updated_count integer not null,
+			skipped_count integer not null,
+			error_message text
+		)`,
 	}
 	for _, statement := range statements {
 		if _, err := db.ExecContext(ctx, statement); err != nil {
@@ -253,7 +340,7 @@ func ensureAnalyticsStore(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-func syncProjects(ctx context.Context, source, store *sql.DB) (int, error) {
+func syncProjects(ctx context.Context, source, store *sql.DB, result *SyncResult) (int, error) {
 	rows, err := source.QueryContext(ctx, selectOpenCodeProjectsSQL)
 	if err != nil {
 		return 0, fmt.Errorf("read OpenCode projects: %w", err)
@@ -267,6 +354,7 @@ func syncProjects(ctx context.Context, source, store *sql.DB) (int, error) {
 		if err := rows.Scan(&id, &name, &path, &created, &updated); err != nil {
 			return 0, err
 		}
+		trackChange(ctx, store, result, "projects", id, fmt.Sprint(updated))
 		if _, err := store.ExecContext(
 			ctx,
 			upsertProjectSQL,
@@ -284,7 +372,7 @@ func syncProjects(ctx context.Context, source, store *sql.DB) (int, error) {
 	return count, rows.Err()
 }
 
-func syncAgentSessions(ctx context.Context, source, store *sql.DB) (int, error) {
+func syncAgentSessions(ctx context.Context, source, store *sql.DB, result *SyncResult) (int, error) {
 	rows, err := source.QueryContext(ctx, selectOpenCodeAgentSessionsSQL)
 	if err != nil {
 		return 0, fmt.Errorf("read OpenCode sessions: %w", err)
@@ -303,6 +391,7 @@ func syncAgentSessions(ctx context.Context, source, store *sql.DB) (int, error) 
 		if archived.Valid {
 			status = "archived"
 		}
+		trackChange(ctx, store, result, "agent_sessions", id, fmt.Sprint(updated))
 		if _, err := store.ExecContext(
 			ctx,
 			upsertAgentSessionSQL,
@@ -338,7 +427,7 @@ type messageData struct {
 	} `json:"tokens"`
 }
 
-func syncModelCalls(ctx context.Context, source, store *sql.DB) (int, error) {
+func syncModelCalls(ctx context.Context, source, store *sql.DB, result *SyncResult) (int, error) {
 	rows, err := source.QueryContext(ctx, selectOpenCodeModelCallsSQL)
 	if err != nil {
 		return 0, fmt.Errorf("read OpenCode messages: %w", err)
@@ -361,6 +450,7 @@ func syncModelCalls(ctx context.Context, source, store *sql.DB) (int, error) {
 			continue
 		}
 
+		trackChange(ctx, store, result, "model_calls", id, fmt.Sprint(updated))
 		if _, err := store.ExecContext(
 			ctx,
 			upsertModelCallSQL,
@@ -384,6 +474,41 @@ func syncModelCalls(ctx context.Context, source, store *sql.DB) (int, error) {
 		count++
 	}
 	return count, rows.Err()
+}
+
+func trackChange(ctx context.Context, store *sql.DB, result *SyncResult, table, sourceID, sourceUpdatedAt string) {
+	var existing string
+	err := store.QueryRowContext(ctx, `select source_updated_at from `+table+` where source = ? and source_id = ?`, openCodeSource, sourceID).Scan(&existing)
+	if err == sql.ErrNoRows {
+		result.Inserted++
+		return
+	}
+	if err != nil {
+		return
+	}
+	if existing == sourceUpdatedAt {
+		result.Skipped++
+		return
+	}
+	result.Updated++
+}
+
+func recordSyncRun(ctx context.Context, store *sql.DB, result *SyncResult) {
+	if result.FinishedAt == "" {
+		result.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	_, _ = store.ExecContext(ctx, `insert into sync_runs (status, started_at, finished_at, inserted_count, updated_count, skipped_count, error_message) values (?, ?, ?, ?, ?, ?, ?)`, result.Status, result.StartedAt, result.FinishedAt, result.Inserted, result.Updated, result.Skipped, result.ErrorMessage)
+}
+
+func sanitizeSyncError(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	if strings.Contains(message, "unsupported OpenCode schema") {
+		return message
+	}
+	return "Usage Sync failed. Check that the configured OpenCode database is available."
 }
 
 func messageHasUsage(message messageData) bool {

--- a/backend/internal/usage/sync_test.go
+++ b/backend/internal/usage/sync_test.go
@@ -65,7 +65,7 @@ func TestOpenCodeUsageSyncStoresProjectsAgentSessionsAndModelCalls(t *testing.T)
 	storePath := filepath.Join(t.TempDir(), "analytics.db")
 	createOpenCodeFixture(t, sourcePath)
 
-	if err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
+	if _, err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
 		t.Fatalf("expected Usage Sync to succeed: %v", err)
 	}
 
@@ -105,10 +105,10 @@ func TestOpenCodeUsageSyncUpsertsRepeatedSyncsAndChangedSourceRecords(t *testing
 	storePath := filepath.Join(t.TempDir(), "analytics.db")
 	createOpenCodeFixture(t, sourcePath)
 
-	if err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
+	if _, err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
 		t.Fatalf("expected initial Usage Sync to succeed: %v", err)
 	}
-	if err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
+	if _, err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
 		t.Fatalf("expected repeated Usage Sync to succeed: %v", err)
 	}
 
@@ -122,7 +122,7 @@ func TestOpenCodeUsageSyncUpsertsRepeatedSyncsAndChangedSourceRecords(t *testing
 	execSQL(t, source, `update session set title = 'Updated usage sync', time_updated = 7000 where id = 'ses_1'`)
 	execSQL(t, source, `update message set time_updated = 8000, data = '{"role":"assistant","modelID":"claude-sonnet-4-5","providerID":"opencode","cost":0.5,"tokens":{"input":11,"output":21,"reasoning":4,"cache":{"read":5,"write":6}},"finish":"tool-calls"}' where id = 'msg_1'`)
 
-	if err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
+	if _, err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
 		t.Fatalf("expected changed source Usage Sync to succeed: %v", err)
 	}
 	assertCount(t, store, "agent_sessions", 1)
@@ -146,6 +146,69 @@ func TestOpenCodeUsageSyncUpsertsRepeatedSyncsAndChangedSourceRecords(t *testing
 	}
 }
 
+func TestOpenCodeUsageSyncPersistsRunHistoryWithCountsAndSanitizedErrors(t *testing.T) {
+	ctx := context.Background()
+	sourcePath := filepath.Join(t.TempDir(), "opencode.db")
+	storePath := filepath.Join(t.TempDir(), "analytics.db")
+	createOpenCodeFixture(t, sourcePath)
+
+	first, err := SyncOpenCode(ctx, sourcePath, storePath)
+	if err != nil {
+		t.Fatalf("expected initial Usage Sync to succeed: %v", err)
+	}
+	if first.Inserted != 3 || first.Updated != 0 || first.Skipped != 0 || first.Status != "success" {
+		t.Fatalf("expected inserted run counts, got %+v", first)
+	}
+
+	second, err := SyncOpenCode(ctx, sourcePath, storePath)
+	if err != nil {
+		t.Fatalf("expected repeated Usage Sync to succeed: %v", err)
+	}
+	if second.Inserted != 0 || second.Updated != 0 || second.Skipped != 3 {
+		t.Fatalf("expected skipped run counts, got %+v", second)
+	}
+
+	missingSourcePath := filepath.Join(t.TempDir(), "secret", "missing-opencode.db")
+	failed, err := SyncOpenCode(ctx, missingSourcePath, storePath)
+	if err == nil {
+		t.Fatalf("expected missing Usage Source sync to fail")
+	}
+	if failed.Status != "error" || failed.ErrorMessage == "" || failed.ErrorMessage == err.Error() {
+		t.Fatalf("expected sanitized sync error, got result=%+v err=%v", failed, err)
+	}
+
+	runs, err := RecentSyncRuns(ctx, storePath, 3)
+	if err != nil {
+		t.Fatalf("expected recent sync runs: %v", err)
+	}
+	if len(runs) != 3 || runs[0].Status != "error" || runs[1].Skipped != 3 || runs[2].Inserted != 3 {
+		t.Fatalf("expected persisted sync run history, got %+v", runs)
+	}
+}
+
+func TestOpenCodeUsageSyncCreatesAnalyticsStoreParentDirectory(t *testing.T) {
+	ctx := context.Background()
+	sourcePath := filepath.Join(t.TempDir(), "opencode.db")
+	storePath := filepath.Join(t.TempDir(), "missing-data-dir", "analytics.db")
+	createOpenCodeFixture(t, sourcePath)
+
+	result, err := SyncOpenCode(ctx, sourcePath, storePath)
+	if err != nil {
+		t.Fatalf("expected Usage Sync to create Analytics Store parent directory: %v", err)
+	}
+	if result.Status != "success" || result.Inserted != 3 {
+		t.Fatalf("expected successful sync into new Analytics Store path, got %+v", result)
+	}
+
+	runs, err := RecentSyncRuns(ctx, storePath, 1)
+	if err != nil {
+		t.Fatalf("expected sync history from created Analytics Store: %v", err)
+	}
+	if len(runs) != 1 || runs[0].Status != "success" {
+		t.Fatalf("expected persisted successful sync run, got %+v", runs)
+	}
+}
+
 func TestOpenCodeUsageSyncIncludesFailedAndAbortedModelCallsWithUsage(t *testing.T) {
 	ctx := context.Background()
 	sourcePath := filepath.Join(t.TempDir(), "opencode.db")
@@ -158,7 +221,7 @@ func TestOpenCodeUsageSyncIncludesFailedAndAbortedModelCallsWithUsage(t *testing
 	execSQL(t, source, `insert into message (id, session_id, time_created, time_updated, data) values ('msg_aborted', 'ses_1', 8000, 8000, '{"role":"assistant","modelID":"claude-opus-4-5","providerID":"opencode","cost":0.1,"tokens":{"input":0,"output":0,"reasoning":0,"cache":{"read":0,"write":0}},"finish":"abort"}')`)
 	execSQL(t, source, `insert into message (id, session_id, time_created, time_updated, data) values ('msg_empty_error', 'ses_1', 9000, 9000, '{"role":"assistant","modelID":"claude-opus-4-5","providerID":"opencode","finish":"error"}')`)
 
-	if err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
+	if _, err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
 		t.Fatalf("expected Usage Sync to succeed: %v", err)
 	}
 
@@ -179,7 +242,7 @@ func TestOpenCodeUsageSyncStoresMetadataOnly(t *testing.T) {
 	execSQL(t, source, `insert into account (id, email, access_token, refresh_token) values ('acct_1', 'secret@example.com', 'access-secret', 'refresh-secret')`)
 	execSQL(t, source, `update message set data = '{"role":"assistant","modelID":"claude-opus-4-5","providerID":"opencode","cost":0.25,"tokens":{"input":10,"output":20,"reasoning":3,"cache":{"read":4,"write":5}},"finish":"stop","text":"assistant response secret","parts":[{"type":"tool","input":"tool input secret","output":"tool output secret"}],"path":{"cwd":"/work/agent-dash"}}' where id = 'msg_1'`)
 
-	if err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
+	if _, err := SyncOpenCode(ctx, sourcePath, storePath); err != nil {
 		t.Fatalf("expected Usage Sync to succeed: %v", err)
 	}
 

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/vue';
+import { cleanup, fireEvent, render, screen } from '@testing-library/vue';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import App from './App.vue';
 
@@ -6,9 +6,10 @@ describe('Usage Overview shell', () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
-  it('shows the connected Analytics Store from backend status', async () => {
+  it('shows Usage Sync diagnostics from backend status', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(
@@ -34,9 +35,9 @@ describe('Usage Overview shell', () => {
     render(App);
 
     expect(await screen.findByText('Usage Overview')).toBeTruthy();
-    expect(await screen.findAllByText('Connected')).toHaveLength(2);
+    expect(await screen.findByText('Usage Sync')).toBeTruthy();
+    expect(await screen.findByText('No sync runs yet')).toBeTruthy();
     expect(await screen.findByText('data/agent-dash.sqlite')).toBeTruthy();
-    expect(await screen.findByText('OpenCode Usage Source')).toBeTruthy();
     expect(await screen.findByText('/Users/test/.local/share/opencode/opencode.db')).toBeTruthy();
   });
 
@@ -49,8 +50,8 @@ describe('Usage Overview shell', () => {
     render(App);
 
     expect(await screen.findByText('Usage Overview')).toBeTruthy();
-    expect(await screen.findAllByText('Disconnected')).toHaveLength(2);
-    expect(await screen.findAllByText('Waiting for backend status...')).toHaveLength(2);
+    expect(await screen.findByText('Disconnected')).toBeTruthy();
+    expect(await screen.findAllByText('Waiting for backend status...')).toHaveLength(3);
   });
 
   it('shows setup guidance when the OpenCode Usage Source is missing', async () => {
@@ -82,6 +83,214 @@ describe('Usage Overview shell', () => {
     ).toHaveLength(2);
     expect(
       await screen.findByText('Open OpenCode once, then refresh this dashboard.'),
+    ).toBeTruthy();
+  });
+
+  it('shows successful Usage Sync diagnostics and can trigger manual refresh', async () => {
+    const fetch = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async (url, init) => {
+        if (url === '/api/usage-sync' && init?.method === 'POST') {
+          return new Response(
+            JSON.stringify({
+              status: 'success',
+              startedAt: '2026-01-01T00:00:00Z',
+              finishedAt: '2026-01-01T00:00:01Z',
+              inserted: 1,
+              updated: 2,
+              skipped: 3,
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            analyticsStorePath: 'data/agent-dash.sqlite',
+            usageSource: {
+              name: 'OpenCode',
+              path: '/opencode.db',
+              available: true,
+              state: 'available',
+            },
+            usageSync: {
+              status: 'success',
+              pollSeconds: 60,
+              nextPollAt: '2026-01-01T00:01:00Z',
+              recentRuns: [],
+              lastRun: {
+                status: 'success',
+                startedAt: '2026-01-01T00:00:00Z',
+                finishedAt: '2026-01-01T00:00:01Z',
+                inserted: 1,
+                updated: 2,
+                skipped: 3,
+              },
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      },
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    render(App);
+
+    expect(await screen.findByText('1 inserted, 2 updated, 3 skipped')).toBeTruthy();
+    expect(await screen.findByText('2026-01-01T00:01:00Z')).toBeTruthy();
+    await fireEvent.click(await screen.findByRole('button', { name: 'Refresh Usage' }));
+    expect(fetch).toHaveBeenCalledWith('/api/usage-sync', { method: 'POST' });
+  });
+
+  it('starts a Usage Sync when the dashboard opens', async () => {
+    let synced = false;
+    const fetch = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async (url, init) => {
+        if (url === '/api/usage-sync' && init?.method === 'POST') {
+          synced = true;
+          return new Response(
+            JSON.stringify({
+              status: 'success',
+              startedAt: '2026-01-01T00:00:00Z',
+              finishedAt: '2026-01-01T00:00:01Z',
+              inserted: 1,
+              updated: 0,
+              skipped: 0,
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            analyticsStorePath: 'data/agent-dash.sqlite',
+            usageSource: {
+              name: 'OpenCode',
+              path: '/opencode.db',
+              available: true,
+              state: 'available',
+            },
+            usageSync: {
+              status: synced ? 'success' : 'never_synced',
+              pollSeconds: 60,
+              nextPollAt: '2026-01-01T00:01:00Z',
+              recentRuns: [],
+              lastRun: synced
+                ? {
+                    status: 'success',
+                    startedAt: '2026-01-01T00:00:00Z',
+                    finishedAt: '2026-01-01T00:00:01Z',
+                    inserted: 1,
+                    updated: 0,
+                    skipped: 0,
+                  }
+                : undefined,
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      },
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    render(App);
+
+    expect(await screen.findByText('1 inserted, 0 updated, 0 skipped')).toBeTruthy();
+    expect(fetch).toHaveBeenCalledWith('/api/usage-sync', { method: 'POST' });
+  });
+
+  it('shows Usage Sync in-progress state during the opening sync', async () => {
+    let finishSync: (response: Response) => void = () => {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<(url: string) => Promise<Response>>((url) => {
+        if (url === '/api/usage-sync') {
+          return new Promise<Response>((resolve) => {
+            finishSync = resolve;
+          });
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ok: true,
+              analyticsStorePath: 'data/agent-dash.sqlite',
+              usageSource: {
+                name: 'OpenCode',
+                path: '/opencode.db',
+                available: true,
+                state: 'available',
+              },
+              usageSync: {
+                status: 'never_synced',
+                pollSeconds: 60,
+                nextPollAt: '2026-01-01T00:01:00Z',
+                recentRuns: [],
+              },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          ),
+        );
+      }),
+    );
+
+    render(App);
+
+    expect(await screen.findByText('Sync in progress...')).toBeTruthy();
+    finishSync(
+      new Response(
+        JSON.stringify({
+          status: 'success',
+          finishedAt: 'done',
+          inserted: 0,
+          updated: 0,
+          skipped: 0,
+        }),
+      ),
+    );
+  });
+
+  it('keeps stale sync data visible when the latest Usage Sync fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              analyticsStorePath: 'data/agent-dash.sqlite',
+              usageSource: {
+                name: 'OpenCode',
+                path: '/opencode.db',
+                available: true,
+                state: 'available',
+              },
+              usageSync: {
+                status: 'error',
+                pollSeconds: 60,
+                nextPollAt: '2026-01-01T00:01:00Z',
+                recentRuns: [],
+                lastRun: {
+                  status: 'error',
+                  finishedAt: '2026-01-01T00:00:01Z',
+                  inserted: 4,
+                  updated: 5,
+                  skipped: 6,
+                  errorMessage:
+                    'Usage Sync failed. Check that the configured OpenCode database is available.',
+                },
+              },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          ),
+      ),
+    );
+
+    render(App);
+
+    expect(await screen.findByText('4 inserted, 5 updated, 6 skipped')).toBeTruthy();
+    expect(
+      await screen.findByText(
+        'Usage Sync failed. Check that the configured OpenCode database is available.',
+      ),
     ).toBeTruthy();
   });
 });

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue';
+import ActionButton from './ui/ActionButton.vue';
 import PanelCard from './ui/PanelCard.vue';
 import StatusItem from './ui/StatusItem.vue';
 
@@ -140,14 +141,9 @@ function formatSyncCounts(run?: SyncRun) {
           :status="syncStatus()"
           :value="syncing ? 'Sync in progress...' : formatSyncCounts(lastRun)"
         />
-        <button
-          class="border-app-accent/70 bg-app-shell/40 text-app-fg-strong hover:border-app-fg-strong hover:bg-app-accent/15 focus-visible:ring-app-accent cursor-pointer rounded-lg border px-4 py-2 text-sm font-bold shadow-sm shadow-black/20 transition hover:-translate-y-0.5 hover:shadow-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-app-shell focus-visible:outline-none active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 disabled:hover:border-app-accent/70 disabled:hover:bg-app-shell/40 disabled:hover:shadow-sm"
-          type="button"
-          :disabled="syncing"
-          @click="runManualSync"
-        >
+        <ActionButton :disabled="syncing" @click="runManualSync">
           {{ syncing ? 'Syncing...' : 'Refresh Usage' }}
-        </button>
+        </ActionButton>
       </div>
       <dl class="text-app-muted grid gap-3 text-sm sm:grid-cols-2">
         <div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import PanelCard from './ui/PanelCard.vue';
 import StatusItem from './ui/StatusItem.vue';
 
@@ -12,35 +12,96 @@ type Status = {
     available: boolean;
     state: string;
   };
+  usageSync?: UsageSync;
+};
+
+type SyncRun = {
+  status: string;
+  startedAt: string;
+  finishedAt: string;
+  inserted: number;
+  updated: number;
+  skipped: number;
+  errorMessage?: string;
+};
+
+type UsageSync = {
+  status: string;
+  lastRun?: SyncRun;
+  recentRuns: SyncRun[];
+  nextPollAt: string;
+  pollSeconds: number;
 };
 
 const status = ref<Status | null>(null);
 const error = ref(false);
+const syncing = ref(false);
+const nextPollAt = ref<string | null>(null);
+let pollTimer: number | undefined;
 
 const waitingMessage = 'Waiting for backend status...';
 
-onMounted(async () => {
+async function loadStatus() {
   try {
     const response = await fetch('/api/status');
     if (!response.ok) {
       throw new Error('Status request failed');
     }
     status.value = await response.json();
+    nextPollAt.value = status.value?.usageSync?.nextPollAt ?? null;
+    error.value = false;
   } catch {
     error.value = true;
   }
+}
+
+onMounted(async () => {
+  await loadStatus();
+  if (status.value?.usageSource?.available) {
+    await runManualSync();
+  }
+  pollTimer = window.setInterval(loadStatus, 60_000);
 });
 
-function backendStatus() {
-  if (status.value?.ok) return 'connected';
+onUnmounted(() => {
+  if (pollTimer) window.clearInterval(pollTimer);
+});
+
+async function runManualSync() {
+  syncing.value = true;
+  try {
+    const response = await fetch('/api/usage-sync', { method: 'POST' });
+    const run = (await response.json()) as SyncRun;
+    status.value = {
+      ...(status.value ?? { ok: true, analyticsStorePath: '' }),
+      usageSync: {
+        status: run.status,
+        lastRun: run,
+        recentRuns: [run, ...(status.value?.usageSync?.recentRuns ?? [])],
+        nextPollAt: new Date(Date.now() + 60_000).toISOString(),
+        pollSeconds: 60,
+      },
+    };
+    await loadStatus();
+  } finally {
+    syncing.value = false;
+  }
+}
+
+const lastRun = computed(() => status.value?.usageSync?.lastRun);
+const latestError = computed(() => lastRun.value?.errorMessage);
+
+function syncStatus() {
+  if (syncing.value) return 'connecting';
   if (error.value) return 'disconnected';
+  if (status.value?.usageSync?.status === 'error') return 'disconnected';
+  if (status.value?.usageSync?.lastRun) return 'connected';
   return 'connecting';
 }
 
-function usageSourceStatus() {
-  if (status.value?.usageSource?.available) return 'connected';
-  if (status.value?.usageSource?.state === 'missing' || error.value) return 'disconnected';
-  return 'connecting';
+function formatSyncCounts(run?: SyncRun) {
+  if (!run) return 'No sync runs yet';
+  return `${run.inserted} inserted, ${run.updated} updated, ${run.skipped} skipped`;
 }
 </script>
 
@@ -72,19 +133,48 @@ function usageSourceStatus() {
       <p class="text-app-fg-strong m-0 wrap-anywhere font-mono">{{ status.usageSource.path }}</p>
     </PanelCard>
 
-    <PanelCard class="mt-14 divide-y divide-panel-border" aria-label="Backend status">
-      <StatusItem
-        class="pb-6"
-        label="Analytics Store"
-        :status="backendStatus()"
-        :value="status?.analyticsStorePath ?? waitingMessage"
-      />
-      <StatusItem
-        class="pt-6"
-        label="OpenCode Usage Source"
-        :status="usageSourceStatus()"
-        :value="status?.usageSource?.path ?? waitingMessage"
-      />
+    <PanelCard class="mt-14 space-y-5" aria-label="Usage Sync status">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <StatusItem
+          label="Usage Sync"
+          :status="syncStatus()"
+          :value="syncing ? 'Sync in progress...' : formatSyncCounts(lastRun)"
+        />
+        <button
+          class="border-app-accent/70 bg-app-shell/40 text-app-fg-strong hover:border-app-fg-strong hover:bg-app-accent/15 focus-visible:ring-app-accent cursor-pointer rounded-lg border px-4 py-2 text-sm font-bold shadow-sm shadow-black/20 transition hover:-translate-y-0.5 hover:shadow-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-app-shell focus-visible:outline-none active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 disabled:hover:border-app-accent/70 disabled:hover:bg-app-shell/40 disabled:hover:shadow-sm"
+          type="button"
+          :disabled="syncing"
+          @click="runManualSync"
+        >
+          {{ syncing ? 'Syncing...' : 'Refresh Usage' }}
+        </button>
+      </div>
+      <dl class="text-app-muted grid gap-3 text-sm sm:grid-cols-2">
+        <div>
+          <dt class="font-bold">Last sync</dt>
+          <dd class="m-0">{{ lastRun?.finishedAt ?? 'Never synced' }}</dd>
+        </div>
+        <div>
+          <dt class="font-bold">Next poll</dt>
+          <dd class="m-0">{{ nextPollAt ?? 'Waiting for backend status...' }}</dd>
+        </div>
+        <div>
+          <dt class="font-bold">Source path</dt>
+          <dd class="m-0 wrap-anywhere font-mono">
+            {{ status?.usageSource?.path ?? waitingMessage }}
+          </dd>
+        </div>
+        <div>
+          <dt class="font-bold">Analytics Store</dt>
+          <dd class="m-0 wrap-anywhere font-mono">
+            {{ status?.analyticsStorePath ?? waitingMessage }}
+          </dd>
+        </div>
+        <div v-if="latestError">
+          <dt class="font-bold">Latest error</dt>
+          <dd class="m-0">{{ latestError }}</dd>
+        </div>
+      </dl>
     </PanelCard>
   </main>
 </template>

--- a/frontend/src/ui/ActionButton.vue
+++ b/frontend/src/ui/ActionButton.vue
@@ -1,0 +1,8 @@
+<template>
+  <button
+    class="border-app-accent/70 bg-app-shell/40 text-app-fg-strong hover:border-app-fg-strong hover:bg-app-accent/15 focus-visible:ring-app-accent cursor-pointer rounded-lg border px-4 py-2 text-sm font-bold shadow-sm shadow-black/20 transition hover:-translate-y-0.5 hover:shadow-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-app-shell focus-visible:outline-none active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 disabled:hover:border-app-accent/70 disabled:hover:bg-app-shell/40 disabled:hover:shadow-sm"
+    type="button"
+  >
+    <slot />
+  </button>
+</template>


### PR DESCRIPTION
## Summary
- Add a manual Usage Sync API endpoint and expose recent sync status through backend status
- Persist sync run history with inserted, updated, skipped counts and sanitized errors
- Replace the redundant dashboard status panel with compact Usage Sync diagnostics and an immediate opening sync

## Verification
- pnpm test
- pnpm --dir frontend format:check
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint

Closes #6

Initial PR generated by openai/gpt-5.5