### PR TITLE
Render First Usage Overview From Synced Metadata

### DIFF
--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/ccmetz/agent-dash/backend/internal/config"
@@ -18,6 +19,7 @@ func NewServer() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/status", statusHandler)
 	mux.HandleFunc("POST /api/usage-sync", syncHandler)
+	mux.HandleFunc("GET /api/usage-overview", usageOverviewHandler)
 	return mux
 }
 
@@ -72,6 +74,39 @@ func syncHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 	}
 	_ = json.NewEncoder(w).Encode(result)
+}
+
+func usageOverviewHandler(w http.ResponseWriter, r *http.Request) {
+	config, err := config.Load()
+	if err != nil {
+		http.Error(w, "failed to load config", http.StatusInternalServerError)
+		return
+	}
+	days := 30
+	if value := r.URL.Query().Get("days"); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed <= 0 {
+			http.Error(w, "invalid days", http.StatusBadRequest)
+			return
+		}
+		days = parsed
+	}
+	end := time.Now().UTC()
+	if value := r.URL.Query().Get("end"); value != "" {
+		parsed, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			http.Error(w, "invalid end", http.StatusBadRequest)
+			return
+		}
+		end = parsed
+	}
+	overview, err := usage.UsageOverview(r.Context(), config.AnalyticsStorePath, days, end)
+	if err != nil {
+		http.Error(w, "failed to load usage overview", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(overview)
 }
 
 func syncStatus(runs []usage.SyncResult) usageSyncResponse {

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -230,6 +230,72 @@ func TestManualUsageSyncEndpointSyncsOpenCodeUsageAndStatusShowsLastRun(t *testi
 	}
 }
 
+func TestUsageOverviewReturnsLastThirtyDaysTotalsAndDailyBuckets(t *testing.T) {
+	dir := t.TempDir()
+	usageSourcePath := filepath.Join(dir, "opencode.db")
+	storePath := filepath.Join(dir, "analytics.db")
+	createSupportedOpenCodeDatabase(t, usageSourcePath)
+	db := openSQLite(t, usageSourcePath)
+	execSQL(t, db, `insert into project (id, worktree, name, time_created, time_updated) values ('proj_1', '/work/agent-dash', 'Agent Dash', 1704067200000, 1704067200000)`)
+	execSQL(t, db, `insert into session (id, project_id, title, time_created, time_updated, time_archived) values ('ses_1', 'proj_1', 'January work', 1704067200000, 1704067200000, null)`)
+	execSQL(t, db, `insert into session (id, project_id, title, time_created, time_updated, time_archived) values ('ses_2', 'proj_1', 'February work', 1706745600000, 1706745600000, null)`)
+	execSQL(t, db, `insert into message (id, session_id, time_created, time_updated, data) values ('msg_1', 'ses_1', 1704067200000, 1704067200000, '{"role":"assistant","modelID":"claude-opus-4-5","providerID":"opencode","cost":0.25,"tokens":{"input":10,"output":20,"reasoning":3,"total":40,"cache":{"read":4,"write":5}},"finish":"stop"}')`)
+	execSQL(t, db, `insert into message (id, session_id, time_created, time_updated, data) values ('msg_2', 'ses_2', 1706745600000, 1706745600000, '{"role":"assistant","modelID":"claude-opus-4-5","providerID":"opencode","cost":0.75,"tokens":{"input":30,"output":40,"reasoning":5,"total":90,"cache":{"read":6,"write":7}},"finish":"stop"}')`)
+	db.Close()
+	configPath := filepath.Join(dir, "local.json")
+	if err := os.WriteFile(configPath, []byte(`{"openCodeDatabasePath":"`+usageSourcePath+`","analyticsStorePath":"`+storePath+`"}`), 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	t.Setenv("AGENT_DASH_CONFIG", configPath)
+
+	syncRequest := httptest.NewRequest(http.MethodPost, "/api/usage-sync", nil)
+	syncResponse := httptest.NewRecorder()
+	NewServer().ServeHTTP(syncResponse, syncRequest)
+	if syncResponse.Code != http.StatusOK {
+		t.Fatalf("expected sync status 200, got %d", syncResponse.Code)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/usage-overview?days=30&end=2024-02-01T00:00:00Z", nil)
+	response := httptest.NewRecorder()
+	NewServer().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected overview status 200, got %d", response.Code)
+	}
+	var body struct {
+		Range struct {
+			Days int `json:"days"`
+		} `json:"range"`
+		Totals struct {
+			Tokens struct {
+				Total      int `json:"total"`
+				Input      int `json:"input"`
+				Output     int `json:"output"`
+				Reasoning  int `json:"reasoning"`
+				CacheRead  int `json:"cacheRead"`
+				CacheWrite int `json:"cacheWrite"`
+			} `json:"tokens"`
+			ActualCost    float64 `json:"actualCost"`
+			AgentSessions int     `json:"agentSessions"`
+			ModelCalls    int     `json:"modelCalls"`
+		} `json:"totals"`
+		Daily []struct {
+			Date       string  `json:"date"`
+			Tokens     int     `json:"tokens"`
+			ActualCost float64 `json:"actualCost"`
+		} `json:"daily"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("expected overview JSON response: %v", err)
+	}
+	if body.Range.Days != 30 || body.Totals.Tokens.Total != 90 || body.Totals.Tokens.Input != 30 || body.Totals.Tokens.Output != 40 || body.Totals.Tokens.Reasoning != 5 || body.Totals.Tokens.CacheRead != 6 || body.Totals.Tokens.CacheWrite != 7 || body.Totals.ActualCost != 0.75 || body.Totals.AgentSessions != 1 || body.Totals.ModelCalls != 1 {
+		t.Fatalf("expected overview totals for last 30 days, got %+v", body.Totals)
+	}
+	if len(body.Daily) != 1 || body.Daily[0].Date != "2024-02-01" || body.Daily[0].Tokens != 90 || body.Daily[0].ActualCost != 0.75 {
+		t.Fatalf("expected daily bucket for included Model Call, got %+v", body.Daily)
+	}
+}
+
 func createSupportedOpenCodeDatabase(t *testing.T, path string) {
 	t.Helper()
 	db := openSQLite(t, path)

--- a/backend/internal/usage/overview.go
+++ b/backend/internal/usage/overview.go
@@ -1,0 +1,122 @@
+package usage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+)
+
+type Overview struct {
+	Range  OverviewRange  `json:"range"`
+	Totals OverviewTotals `json:"totals"`
+	Daily  []DailyUsage   `json:"daily"`
+}
+
+type OverviewRange struct {
+	Days  int    `json:"days"`
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+type OverviewTotals struct {
+	Tokens        TokenTotals `json:"tokens"`
+	ActualCost    float64     `json:"actualCost"`
+	AgentSessions int         `json:"agentSessions"`
+	ModelCalls    int         `json:"modelCalls"`
+}
+
+type TokenTotals struct {
+	Total      int `json:"total"`
+	Input      int `json:"input"`
+	Output     int `json:"output"`
+	Reasoning  int `json:"reasoning"`
+	CacheRead  int `json:"cacheRead"`
+	CacheWrite int `json:"cacheWrite"`
+}
+
+type DailyUsage struct {
+	Date       string  `json:"date"`
+	Tokens     int     `json:"tokens"`
+	ActualCost float64 `json:"actualCost"`
+}
+
+func UsageOverview(ctx context.Context, storePath string, days int, end time.Time) (Overview, error) {
+	if days <= 0 {
+		days = 30
+	}
+	end = end.UTC()
+	start := end.AddDate(0, 0, -days)
+	overview := Overview{Range: OverviewRange{Days: days, Start: start.Format(time.RFC3339), End: end.Format(time.RFC3339)}, Daily: []DailyUsage{}}
+	if _, err := os.Stat(storePath); errors.Is(err, os.ErrNotExist) {
+		return overview, nil
+	} else if err != nil {
+		return overview, err
+	}
+
+	store, err := openAnalyticsStore(storePath)
+	if err != nil {
+		return overview, err
+	}
+	defer store.Close()
+	if err := ensureAnalyticsStore(ctx, store); err != nil {
+		return overview, err
+	}
+
+	startMillis := start.UnixMilli()
+	endMillis := end.UnixMilli()
+	if err := store.QueryRowContext(ctx, `
+		select
+			coalesce(sum(coalesce(total_tokens, input_tokens + output_tokens + reasoning_tokens + cache_read_tokens + cache_write_tokens)), 0),
+			coalesce(sum(input_tokens), 0),
+			coalesce(sum(output_tokens), 0),
+			coalesce(sum(reasoning_tokens), 0),
+			coalesce(sum(cache_read_tokens), 0),
+			coalesce(sum(cache_write_tokens), 0),
+			coalesce(sum(actual_cost), 0),
+			count(*)
+		from model_calls
+		where cast(source_created_at as integer) >= ? and cast(source_created_at as integer) <= ?
+	`, startMillis, endMillis).Scan(
+		&overview.Totals.Tokens.Total,
+		&overview.Totals.Tokens.Input,
+		&overview.Totals.Tokens.Output,
+		&overview.Totals.Tokens.Reasoning,
+		&overview.Totals.Tokens.CacheRead,
+		&overview.Totals.Tokens.CacheWrite,
+		&overview.Totals.ActualCost,
+		&overview.Totals.ModelCalls,
+	); err != nil {
+		return overview, err
+	}
+	if err := store.QueryRowContext(ctx, `
+		select count(distinct session_source_id)
+		from model_calls
+		where cast(source_created_at as integer) >= ? and cast(source_created_at as integer) <= ?
+	`, startMillis, endMillis).Scan(&overview.Totals.AgentSessions); err != nil {
+		return overview, err
+	}
+
+	rows, err := store.QueryContext(ctx, `
+		select
+			date(cast(source_created_at as integer) / 1000, 'unixepoch') usage_date,
+			coalesce(sum(coalesce(total_tokens, input_tokens + output_tokens + reasoning_tokens + cache_read_tokens + cache_write_tokens)), 0),
+			coalesce(sum(actual_cost), 0)
+		from model_calls
+		where cast(source_created_at as integer) >= ? and cast(source_created_at as integer) <= ?
+		group by usage_date
+		order by usage_date
+	`, startMillis, endMillis)
+	if err != nil {
+		return overview, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var day DailyUsage
+		if err := rows.Scan(&day.Date, &day.Tokens, &day.ActualCost); err != nil {
+			return overview, err
+		}
+		overview.Daily = append(overview.Daily, day)
+	}
+	return overview, rows.Err()
+}

--- a/backend/internal/usage/sync.go
+++ b/backend/internal/usage/sync.go
@@ -122,10 +122,11 @@ const upsertModelCallSQL = `
 		reasoning_tokens,
 		cache_read_tokens,
 		cache_write_tokens,
+		total_tokens,
 		actual_cost,
 		source_created_at,
 		source_updated_at
-	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	on conflict(source, source_id) do update set
 		session_source_id = excluded.session_source_id,
 		provider = excluded.provider,
@@ -136,6 +137,7 @@ const upsertModelCallSQL = `
 		reasoning_tokens = excluded.reasoning_tokens,
 		cache_read_tokens = excluded.cache_read_tokens,
 		cache_write_tokens = excluded.cache_write_tokens,
+		total_tokens = excluded.total_tokens,
 		actual_cost = excluded.actual_cost,
 		source_created_at = excluded.source_created_at,
 		source_updated_at = excluded.source_updated_at
@@ -316,6 +318,7 @@ func ensureAnalyticsStore(ctx context.Context, db *sql.DB) error {
 			reasoning_tokens integer not null,
 			cache_read_tokens integer not null,
 			cache_write_tokens integer not null,
+			total_tokens integer,
 			actual_cost real not null,
 			source_created_at text not null,
 			source_updated_at text not null,
@@ -337,7 +340,22 @@ func ensureAnalyticsStore(ctx context.Context, db *sql.DB) error {
 			return err
 		}
 	}
+	if err := ensureColumn(ctx, db, "model_calls", "total_tokens", "integer"); err != nil {
+		return err
+	}
 	return nil
+}
+
+func ensureColumn(ctx context.Context, db *sql.DB, table, column, columnType string) error {
+	columns, err := tableColumns(ctx, db, table)
+	if err != nil {
+		return err
+	}
+	if columns[column] {
+		return nil
+	}
+	_, err = db.ExecContext(ctx, `alter table `+table+` add column `+column+` `+columnType)
+	return err
 }
 
 func syncProjects(ctx context.Context, source, store *sql.DB, result *SyncResult) (int, error) {
@@ -420,6 +438,7 @@ type messageData struct {
 		Input     int `json:"input"`
 		Output    int `json:"output"`
 		Reasoning int `json:"reasoning"`
+		Total     int `json:"total"`
 		Cache     struct {
 			Read  int `json:"read"`
 			Write int `json:"write"`
@@ -465,6 +484,7 @@ func syncModelCalls(ctx context.Context, source, store *sql.DB, result *SyncResu
 			message.Tokens.Reasoning,
 			message.Tokens.Cache.Read,
 			message.Tokens.Cache.Write,
+			nullableTotalTokens(message),
 			message.Cost,
 			fmt.Sprint(created),
 			fmt.Sprint(updated),
@@ -474,6 +494,13 @@ func syncModelCalls(ctx context.Context, source, store *sql.DB, result *SyncResu
 		count++
 	}
 	return count, rows.Err()
+}
+
+func nullableTotalTokens(message messageData) sql.NullInt64 {
+	if message.Tokens.Total == 0 {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: int64(message.Tokens.Total), Valid: true}
 }
 
 func trackChange(ctx context.Context, store *sql.DB, result *SyncResult, table, sourceID, sourceUpdatedAt string) {

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -141,6 +141,145 @@ describe('Usage Overview shell', () => {
     expect(fetch).toHaveBeenCalledWith('/api/usage-sync', { method: 'POST' });
   });
 
+  it('loads the last 30 days Usage Overview with cards and daily charts', async () => {
+    const fetch = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async (url, init) => {
+        if (url === '/api/usage-sync' && init?.method === 'POST') {
+          return new Response(
+            JSON.stringify({ status: 'success', inserted: 0, updated: 0, skipped: 0 }),
+            {
+              headers: { 'Content-Type': 'application/json' },
+            },
+          );
+        }
+        if (url === '/api/usage-overview?days=30') {
+          return new Response(
+            JSON.stringify({
+              range: { days: 30, start: '2024-01-02T00:00:00Z', end: '2024-02-01T00:00:00Z' },
+              totals: {
+                tokens: {
+                  total: 900,
+                  input: 300,
+                  output: 400,
+                  reasoning: 100,
+                  cacheRead: 50,
+                  cacheWrite: 50,
+                },
+                actualCost: 1.25,
+                agentSessions: 2,
+                modelCalls: 3,
+              },
+              daily: [
+                { date: '2024-01-31', tokens: 300, actualCost: 0.5 },
+                { date: '2024-02-01', tokens: 600, actualCost: 0.75 },
+              ],
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            analyticsStorePath: 'data/agent-dash.sqlite',
+            usageSource: {
+              name: 'OpenCode',
+              path: '/opencode.db',
+              available: true,
+              state: 'available',
+            },
+            usageSync: {
+              status: 'success',
+              pollSeconds: 60,
+              nextPollAt: '2026-01-01T00:01:00Z',
+              recentRuns: [],
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+      },
+    );
+    vi.stubGlobal('fetch', fetch);
+
+    render(App);
+
+    expect(await screen.findByText('Last 30 days')).toBeTruthy();
+    expect(await screen.findByText('900')).toBeTruthy();
+    expect(await screen.findByText('$1.25')).toBeTruthy();
+    expect(await screen.findByText('2')).toBeTruthy();
+    expect(await screen.findByText('3')).toBeTruthy();
+    expect(await screen.findByText('Daily Tokens')).toBeTruthy();
+    expect(await screen.findByText('Daily Actual Cost')).toBeTruthy();
+    expect(await screen.findByText('2024-02-01: 600 tokens')).toBeTruthy();
+    expect(await screen.findByText('2024-02-01: $0.75')).toBeTruthy();
+    expect(fetch).toHaveBeenCalledWith('/api/usage-overview?days=30');
+  });
+
+  it('shows Usage Overview loading and empty chart states', async () => {
+    let finishOverview: (response: Response) => void = () => {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<(url: string, init?: RequestInit) => Promise<Response>>((url, init) => {
+        if (url === '/api/usage-sync' && init?.method === 'POST') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ status: 'success', inserted: 0, updated: 0, skipped: 0 }),
+              {
+                headers: { 'Content-Type': 'application/json' },
+              },
+            ),
+          );
+        }
+        if (url === '/api/usage-overview?days=30') {
+          return new Promise<Response>((resolve) => {
+            finishOverview = resolve;
+          });
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ok: true,
+              analyticsStorePath: 'data/agent-dash.sqlite',
+              usageSource: {
+                name: 'OpenCode',
+                path: '/opencode.db',
+                available: true,
+                state: 'available',
+              },
+              usageSync: {
+                status: 'success',
+                pollSeconds: 60,
+                nextPollAt: '2026-01-01T00:01:00Z',
+                recentRuns: [],
+              },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          ),
+        );
+      }),
+    );
+
+    render(App);
+
+    expect(await screen.findByText('Loading Usage Overview...')).toBeTruthy();
+    finishOverview(
+      new Response(
+        JSON.stringify({
+          range: { days: 30, start: '2024-01-02T00:00:00Z', end: '2024-02-01T00:00:00Z' },
+          totals: {
+            tokens: { total: 0, input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0 },
+            actualCost: 0,
+            agentSessions: 0,
+            modelCalls: 0,
+          },
+          daily: [],
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    expect(await screen.findByText('No daily token data yet.')).toBeTruthy();
+    expect(await screen.findByText('No daily Actual Cost data yet.')).toBeTruthy();
+  });
+
   it('starts a Usage Sync when the dashboard opens', async () => {
     let synced = false;
     const fetch = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -34,9 +34,38 @@ type UsageSync = {
   pollSeconds: number;
 };
 
+type UsageOverview = {
+  range: {
+    days: number;
+    start: string;
+    end: string;
+  };
+  totals: {
+    tokens: {
+      total: number;
+      input: number;
+      output: number;
+      reasoning: number;
+      cacheRead: number;
+      cacheWrite: number;
+    };
+    actualCost: number;
+    agentSessions: number;
+    modelCalls: number;
+  };
+  daily: Array<{
+    date: string;
+    tokens: number;
+    actualCost: number;
+  }>;
+};
+
 const status = ref<Status | null>(null);
+const overview = ref<UsageOverview | null>(null);
 const error = ref(false);
 const syncing = ref(false);
+const overviewLoading = ref(false);
+const overviewError = ref(false);
 const nextPollAt = ref<string | null>(null);
 let pollTimer: number | undefined;
 
@@ -56,10 +85,30 @@ async function loadStatus() {
   }
 }
 
+async function loadOverview() {
+  overviewLoading.value = true;
+  try {
+    const response = await fetch('/api/usage-overview?days=30');
+    if (!response.ok) {
+      throw new Error('Usage Overview request failed');
+    }
+    const nextOverview = (await response.json()) as UsageOverview;
+    if (nextOverview.totals && Array.isArray(nextOverview.daily)) {
+      overview.value = nextOverview;
+      overviewError.value = false;
+    }
+  } catch {
+    overviewError.value = true;
+  } finally {
+    overviewLoading.value = false;
+  }
+}
+
 onMounted(async () => {
   await loadStatus();
   if (status.value?.usageSource?.available) {
     await runManualSync();
+    await loadOverview();
   }
   pollTimer = window.setInterval(loadStatus, 60_000);
 });
@@ -84,6 +133,7 @@ async function runManualSync() {
       },
     };
     await loadStatus();
+    await loadOverview();
   } finally {
     syncing.value = false;
   }
@@ -103,6 +153,24 @@ function syncStatus() {
 function formatSyncCounts(run?: SyncRun) {
   if (!run) return 'No sync runs yet';
   return `${run.inserted} inserted, ${run.updated} updated, ${run.skipped} skipped`;
+}
+
+function formatInteger(value?: number) {
+  return value == null ? '0' : new Intl.NumberFormat('en-US').format(value);
+}
+
+function formatCost(value?: number) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value ?? 0);
+}
+
+function tokenBarWidth(tokens: number) {
+  const max = Math.max(...(overview.value?.daily.map((day) => day.tokens) ?? [0]), 1);
+  return `${Math.max((tokens / max) * 100, 4)}%`;
+}
+
+function costBarWidth(cost: number) {
+  const max = Math.max(...(overview.value?.daily.map((day) => day.actualCost) ?? [0]), 1);
+  return `${Math.max((cost / max) * 100, 4)}%`;
 }
 </script>
 
@@ -133,6 +201,113 @@ function formatSyncCounts(run?: SyncRun) {
       <p class="text-app-muted m-0">Checked path:</p>
       <p class="text-app-fg-strong m-0 wrap-anywhere font-mono">{{ status.usageSource.path }}</p>
     </PanelCard>
+
+    <section class="mt-12 max-w-6xl space-y-5" aria-label="Last 30 days Usage Overview">
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p class="text-app-accent text-xs font-bold tracking-[0.12em] uppercase">Last 30 days</p>
+          <h2 class="text-app-fg-strong m-0 text-3xl font-bold">Usage Metadata</h2>
+        </div>
+        <p class="text-app-muted m-0 text-sm">
+          {{
+            overviewLoading
+              ? 'Loading Usage Overview...'
+              : overviewError
+                ? 'Usage Overview unavailable'
+                : 'Synced Model Calls'
+          }}
+        </p>
+      </div>
+
+      <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <PanelCard class="space-y-2" aria-label="Total tokens">
+          <p class="text-app-accent m-0 text-xs font-bold tracking-[0.12em] uppercase">Tokens</p>
+          <p class="text-app-fg-strong m-0 text-4xl font-bold">
+            {{ formatInteger(overview?.totals.tokens.total) }}
+          </p>
+          <p class="text-app-muted m-0 text-sm">
+            Input {{ formatInteger(overview?.totals.tokens.input) }} / Output
+            {{ formatInteger(overview?.totals.tokens.output) }}
+          </p>
+        </PanelCard>
+        <PanelCard class="space-y-2" aria-label="Actual Cost">
+          <p class="text-app-accent m-0 text-xs font-bold tracking-[0.12em] uppercase">
+            Actual Cost
+          </p>
+          <p class="text-app-fg-strong m-0 text-4xl font-bold">
+            {{ formatCost(overview?.totals.actualCost) }}
+          </p>
+          <p class="text-app-muted m-0 text-sm">Source-reported spend</p>
+        </PanelCard>
+        <PanelCard class="space-y-2" aria-label="Agent Sessions">
+          <p class="text-app-accent m-0 text-xs font-bold tracking-[0.12em] uppercase">
+            Agent Sessions
+          </p>
+          <p class="text-app-fg-strong m-0 text-4xl font-bold">
+            {{ formatInteger(overview?.totals.agentSessions) }}
+          </p>
+          <p class="text-app-muted m-0 text-sm">Sessions with Model Calls</p>
+        </PanelCard>
+        <PanelCard class="space-y-2" aria-label="Model Calls">
+          <p class="text-app-accent m-0 text-xs font-bold tracking-[0.12em] uppercase">
+            Model Calls
+          </p>
+          <p class="text-app-fg-strong m-0 text-4xl font-bold">
+            {{ formatInteger(overview?.totals.modelCalls) }}
+          </p>
+          <p class="text-app-muted m-0 text-sm">Synced assistant calls</p>
+        </PanelCard>
+      </div>
+
+      <div class="grid gap-5 lg:grid-cols-2">
+        <PanelCard class="space-y-4" aria-label="Daily Tokens chart">
+          <h3 class="text-app-fg-strong m-0 text-xl font-bold">Daily Tokens</h3>
+          <p v-if="!overview?.daily.length" class="text-app-muted m-0">No daily token data yet.</p>
+          <ol v-else class="m-0 space-y-3 p-0">
+            <li
+              v-for="day in overview.daily"
+              :key="`tokens-${day.date}`"
+              class="list-none space-y-1"
+            >
+              <div class="flex justify-between gap-4 text-sm">
+                <span class="text-app-muted">{{ day.date }}</span>
+                <span class="text-app-fg-strong"
+                  >{{ day.date }}: {{ formatInteger(day.tokens) }} tokens</span
+                >
+              </div>
+              <div class="bg-app-shell-deep h-3 overflow-hidden rounded-full">
+                <div
+                  class="bg-app-accent h-full rounded-full"
+                  :style="{ width: tokenBarWidth(day.tokens) }"
+                ></div>
+              </div>
+            </li>
+          </ol>
+        </PanelCard>
+        <PanelCard class="space-y-4" aria-label="Daily Actual Cost chart">
+          <h3 class="text-app-fg-strong m-0 text-xl font-bold">Daily Actual Cost</h3>
+          <p v-if="!overview?.daily.length" class="text-app-muted m-0">
+            No daily Actual Cost data yet.
+          </p>
+          <ol v-else class="m-0 space-y-3 p-0">
+            <li v-for="day in overview.daily" :key="`cost-${day.date}`" class="list-none space-y-1">
+              <div class="flex justify-between gap-4 text-sm">
+                <span class="text-app-muted">{{ day.date }}</span>
+                <span class="text-app-fg-strong"
+                  >{{ day.date }}: {{ formatCost(day.actualCost) }}</span
+                >
+              </div>
+              <div class="bg-app-shell-deep h-3 overflow-hidden rounded-full">
+                <div
+                  class="bg-status-success h-full rounded-full"
+                  :style="{ width: costBarWidth(day.actualCost) }"
+                ></div>
+              </div>
+            </li>
+          </ol>
+        </PanelCard>
+      </div>
+    </section>
 
     <PanelCard class="mt-14 space-y-5" aria-label="Usage Sync status">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">


### PR DESCRIPTION
## Summary

Implements the first Usage Overview backed by synced Model Calls, as specified in #5.

## Changes

### Backend
- Added `GET /api/usage-overview?days=30` endpoint that returns:
  - Aggregate totals: total tokens (with input/output/reasoning/cache breakdown), Actual Cost, Agent Sessions, and Model Calls
  - Daily buckets for token usage and Actual Cost based on Model Call creation time
- Added `total_tokens` field to the analytics store model_calls table, populated from source-reported token totals when available
- Added `ensureColumn` helper to handle schema migration for existing analytics stores

### Frontend
- Defaults the Usage Overview to the last 30 days on dashboard load
- Renders four overview cards: Total Tokens, Actual Cost, Agent Sessions, Model Calls
- Renders two adjacent daily charts: Daily Tokens and Daily Actual Cost with accessible data labels
- Handles loading and empty chart states

### Tests
- Backend integration test verifies totals and daily buckets against known fixture data
- Frontend component tests cover overview cards, loading/empty states, and chart data rendering

## Acceptance Criteria

- [x] Backend exposes aggregate endpoints for total tokens, Actual Cost, Agent Sessions, and Model Calls
- [x] Backend exposes daily token and Actual Cost buckets based on Model Call creation time
- [x] Frontend defaults the Usage Overview to the last 30 days
- [x] Frontend renders overview cards and separate adjacent daily token and Actual Cost charts
- [x] Token totals use the source-reported total, with available breakdowns represented in API data
- [x] Backend aggregation tests cover totals and daily buckets against known fixture data
- [x] Frontend component tests cover overview cards, loading/empty states, and chart data rendering states

## Related

Closes #5

---

Initial PR generated by kimi-k2.6
